### PR TITLE
Fix SonarQube security hotspots

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -25,7 +25,7 @@ jobs:
     - run: npm run lint:ci --if-present
     - run: npm run test:coverage --if-present
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/lcov.info

--- a/src/__tests/WalletAdvertiser.test.ts
+++ b/src/__tests/WalletAdvertiser.test.ts
@@ -59,7 +59,7 @@ describe('WalletAdvertiser', () => {
   describe('Constructor', () => {
     it('throws if provided a non-advertisable URI', () => {
       expect(() => {
-        new WalletAdvertiser('test', testPrivateKeyHex, 'https://fake-storage-url.com', 'ftp://bad-protocol.com')
+        new WalletAdvertiser('test', testPrivateKeyHex, 'https://fake-storage-url.com', 'xyz://bad-protocol.com')
       }).toThrow('Refusing to initialize with non-advertisable URI')
     })
 


### PR DESCRIPTION
## Summary
- **Pin GitHub Action to full commit SHA**: `codecov/codecov-action@v4` replaced with `codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` to address SonarQube rule S7637 (supply chain integrity)
- **Remove clear-text protocol from test**: Changed `ftp://bad-protocol.com` to `xyz://bad-protocol.com` in `WalletAdvertiser.test.ts` to address SonarQube rule S5332 (clear-text protocol) while preserving the test's intent of verifying non-advertisable URI rejection

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (42/42 tests)
- [ ] SonarCloud analysis shows 100% security hotspots reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)